### PR TITLE
Add 3 new features - joinfeeds, excludes, and date cutoff

### DIFF
--- a/main.js
+++ b/main.js
@@ -180,7 +180,7 @@ const bot = new LemmyBot.LemmyBot({
                     for (const item of rss.items) {
                         let pin_days = 0;
                         const itemDate = new Date(item['dc:date']);
-                        console.log(`${chalk.green('ITEM DATE:')} ${cutoffDate}`);
+                        console.log(`${chalk.green('ITEM DATE:')} ${itemDate}`);
 
                         //if item is newer than 6 months old, continue
                         if (itemDate > cutoffDate) { 

--- a/main.js
+++ b/main.js
@@ -177,8 +177,9 @@ const bot = new LemmyBot.LemmyBot({
                         let pin_days = 0;
                         const itemDate = new Date(item['dc:date']);
                         const cutoffDate = new Date();
+                        console.log(`${chalk.green('CURRENT DATE:')} ${cutoffDate}`);
                         cutoffDate.setMonth(cutoffDate.getMonth() - 6);  // set to 6 months ago
-
+                        console.log(`${chalk.green('CUTOFF DATE:')} ${cutoffDate}`);
                         //if item is newer than 6 months old, continue
                         if (itemDate > cutoffDate) { 
                             // if has categories then see if it's a pin
@@ -200,6 +201,7 @@ const bot = new LemmyBot.LemmyBot({
                                         return console.error(err.message);
                                     }
                                 }
+                                console.log(`${chalk.green('INSERTED:')} ${item.link} into database.`);
 
                                 for (const community of communities) {
                                     if (community.feeds.includes(feed.name)) {
@@ -207,6 +209,7 @@ const bot = new LemmyBot.LemmyBot({
 
                                         // If 'exclude' exists for the current community, parse its feeds and collect their items
                                         if (community.exclude) {
+                                            console.log(`${chalk.green('FETCHING:')} exlude feeds for ${community.slug}`);
                                             for (const excludeFeed of community.exclude) {
                                                 const excludeRss = await parser.parseURL(excludeFeed);
                                                 for (const excludeItem of excludeRss.items) {
@@ -217,6 +220,7 @@ const bot = new LemmyBot.LemmyBot({
 
                                         // Process the item only if its link is not in the excludeItems list
                                         if (!excludeItems.includes(item.link)) {
+                                            console.log(`${chalk.green('CREATING:')} post for link ${item.link} in ${community.slug }`);
                                             const communityId = await getCommunityId({ name: community.slug, instance: community.instance });
                                             await createPost({
                                                 name: item.title,

--- a/main.js
+++ b/main.js
@@ -204,6 +204,7 @@ const bot = new LemmyBot.LemmyBot({
                                         return;
                                     } else {
                                         return console.error(err.message);
+                                        console.log(`${chalk.green('ERROR:')} ${err.message}`);
                                     }
                                 }
                                 console.log(`${chalk.green('INSERTED:')} ${item.link} into database.`);

--- a/main.js
+++ b/main.js
@@ -214,9 +214,9 @@ const bot = new LemmyBot.LemmyBot({
                                         let excludeItems = [];
 
                                         // If 'exclude' exists for the current community, parse its feeds and collect their items
-                                        if (community.exclude) {
+                                        if (community.exclude.includes(exclude.name)) {
                                             console.log(`${chalk.green('FETCHING:')} exclude feeds for ${community.slug}`);
-                                            for (const excludeFeed of community.exclude) {
+                                            for (const excludeFeed of exclude) {
                                                 const excludeRss = await parser.parseURL(excludeFeed.url);
                                                 for (const excludeItem of excludeRss.items) {
                                                     excludeItems.push(excludeItem.link);

--- a/main.js
+++ b/main.js
@@ -214,7 +214,7 @@ const bot = new LemmyBot.LemmyBot({
                                         let excludeItems = [];
 
                                         // If 'exclude' exists for the current community, parse its feeds and collect their items
-                                        if (community.exclude.includes(exclude.name)) {
+                                        if (community.exclude) {
                                             console.log(`${chalk.green('FETCHING:')} exclude feeds for ${community.slug}`);
                                             for (const excludeFeed of exclude) {
                                                 const excludeRss = await parser.parseURL(excludeFeed.url);

--- a/main.js
+++ b/main.js
@@ -249,8 +249,17 @@ const bot = new LemmyBot.LemmyBot({
                         }
                     }
 
-                    let commonItems = rss.items.filter(item => joinedItems.map(i => i.link).includes(item.link) && !excludeItems.includes(item.link));
-
+                    let commonItems = rss.items.filter(item => {
+                        if (feed.joinfeeds && feed.exclude) {
+                            return joinedItems.map(i => i.link).includes(item.link) && !excludeItems.includes(item.link);
+                        } else if (feed.joinfeeds) {
+                            return joinedItems.map(i => i.link).includes(item.link);
+                        } else if (feed.exclude) {
+                            return !excludeItems.includes(item.link);
+                        } else {
+                            return true;
+                        }
+                    });
 
                     for (const item of commonItems) {
                         let pin_days = 0;

--- a/main.js
+++ b/main.js
@@ -169,6 +169,7 @@ const bot = new LemmyBot.LemmyBot({
             timezone: 'America/Phoenix',
             runAtStart: true,
             doTask: async ({getCommunityId, createPost}) => {
+                console.log(`${chalk.green('STARTED:')} RSS Feed Fetcher.`);
                 for (const feed of feeds) {
                     const rss = await parser.parseURL(feed.url);
 

--- a/main.js
+++ b/main.js
@@ -240,8 +240,9 @@ const bot = new LemmyBot.LemmyBot({
                             });
                         
                         }
-                    console.log(`${chalk.green('COMPLETE:')} Feed ${feed.name} processed.`);
+                    
                     }
+                console.log(`${chalk.green('COMPLETE:')} Feed ${feed.name} processed.`);
                 }
             }
         },

--- a/main.js
+++ b/main.js
@@ -208,7 +208,7 @@ const bot = new LemmyBot.LemmyBot({
     },
     schedule: [
         {
-            cronExpression: '0 */20 * * * *',
+            cronExpression: '0 */10 * * * *',
             timezone: 'America/Toronto',
             doTask: async ({getCommunityId, createPost}) => {
                 console.log(`${chalk.green('STARTED:')} RSS Feed Fetcher.`);

--- a/main.js
+++ b/main.js
@@ -82,7 +82,7 @@ const communities = [
 const feeds = [
     {
         name: 'localnews',
-        url: 'https://www.tucsonsentinel.com/local/rss/',
+        url: 'https://www.tucsonsentinel.com/category/rss/local/',
         content: 'description',
         exclude: [
             'localpolitics',  // the local feed contains politics, which we don't want. So we exclude the localpolitics feed to get local news only.

--- a/main.js
+++ b/main.js
@@ -167,6 +167,7 @@ const bot = new LemmyBot.LemmyBot({
         {
             cronExpression: '0 */10 * * * *',
             timezone: 'America/Phoenix',
+            runAtStart: true,
             doTask: async ({getCommunityId, createPost}) => {
                 for (const feed of feeds) {
                     const rss = await parser.parseURL(feed.url);

--- a/main.js
+++ b/main.js
@@ -185,6 +185,7 @@ const bot = new LemmyBot.LemmyBot({
                         //if item is newer than 6 months old, continue
                         if (itemDate > cutoffDate) { 
                             console.log(`${chalk.green('RECENT:')} true`);
+                            console.log(`${chalk.green('LINK:')} ${item.link}`);
                             // if has categories then see if it's a pin
                             if (feed.pinCategories && item.categories) {
                                 for (const category of item.categories) {
@@ -212,7 +213,7 @@ const bot = new LemmyBot.LemmyBot({
 
                                         // If 'exclude' exists for the current community, parse its feeds and collect their items
                                         if (community.exclude) {
-                                            console.log(`${chalk.green('FETCHING:')} exlude feeds for ${community.slug}`);
+                                            console.log(`${chalk.green('FETCHING:')} exclude feeds for ${community.slug}`);
                                             for (const excludeFeed of community.exclude) {
                                                 const excludeRss = await parser.parseURL(excludeFeed);
                                                 for (const excludeItem of excludeRss.items) {

--- a/main.js
+++ b/main.js
@@ -254,7 +254,7 @@ const bot = new LemmyBot.LemmyBot({
 
                     for (const item of commonItems) {
                         let pin_days = 0;
-                        const itemDate = new Date(item[feed.datefield].trim());
+                        const itemDate = new Date((feed.datefield ? item[feed.datefield] : item.pubDate).trim());
                         console.log(`${chalk.white('ITEM DATE:')} ${itemDate}`);
                         //if item is newer than 6 months old, continue
                         if (itemDate > cutoffDate) { 

--- a/main.js
+++ b/main.js
@@ -61,40 +61,78 @@ const db = new sqlite3.Database('mega.sqlite3', (err) => {
 
 // -----------------------------------------------------------------------------
 // Data
+// 
+
 
 const communities = [
     {
-        slug: 'localnews',
-        instance: 'tucson.social',
+        slug: 'godot',
+        instance: 'programming.dev',
         feeds: [
-            'localnews',
+            'godot',
         ]
     },
     {
-        slug: 'tucsonpolitics',
-        instance: 'tucson.social',
+        slug: 'unreal_engine',
+        instance: 'programming.dev',
         feeds: [
-            'localpolitics',
+            'unreal',
         ]
     },
 ]
 
+// Feed data is stored in the following format: 
+// joinfeeds will only include posts in common between the source feed and those in the list - It is processed first.
+// exclude will remove posts from the feed based on the contents of another feed - It is processed second.
+// pinCategories will pin posts in the feed that match the category name and are within the specified number of days
+// content is the name of the field in the feed that contains the post content. Defaults to 'content' if not specified
+//
+// const feeds = [
+//     {
+//         name: 'feedname',
+//         url: 'https://www.some-news-site.com/category/rss/news/',
+//         content: 'description',
+//         exclude: [
+//             'feedname2',  // the feed contains posts from feedname2, which we don't want. So we exclude feedname2 to get feedname only.
+//         ],
+//         joinfeeds: [
+//             'feedname3', // the feed contains posts from feedname3, which we want. So we join feedname3 to get feedname and feedname3.
+//         ],
+//         pinCategories: [
+//             { name: 'categoryname', days: 7 }, // the feed contains posts from categoryname, which we want. So we pin categoryname posts from the feed.
+//         ]
+//     },
+//     { 
+//         name: 'feedname2',
+//         url: 'https://www.some-news-site.com/category/rss/politics/',
+//         content: 'content'
+//     },
+//     {
+//         name: 'feedname3',
+//         url: 'https://www.some-news-site.com/category/rss/localnews/',
+//         content: 'content'
+//     }
+// ]
+//
+
+
 const feeds = [
     {
-        name: 'localnews',
-        url: 'https://www.tucsonsentinel.com/category/rss/local/',
-        content: 'description',
-        exclude: [
-            'localpolitics',  // the local feed contains politics, which we don't want. So we exclude the localpolitics feed to get local news only.
-        ]
+        name: 'godot',
+        url: 'https://godotengine.org/rss.xml',
+        pinCategories: [
+            { name: 'Release', days: 7 },
+            { name: 'Pre-release', days: 7 },
+        ],
     },
     {
-        name: 'localpolitics',
-        url: 'https://www.tucsonsentinel.com/category/rss/politics/',
-        content: 'description',
-        joinfeeds: [
-            'localnews', // the politics feed contains national politics, which we don't want. So we join the local news feed to get local politics.
-        ]
+        name: 'unreal',
+        url: 'https://www.unrealengine.com/en-US/rss',
+        content: 'summary',
+    },
+    {
+        name: 'unity',
+        url: 'https://blogs.unity3d.com/feed/',
     }
 ]
 

--- a/main.js
+++ b/main.js
@@ -172,16 +172,19 @@ const bot = new LemmyBot.LemmyBot({
                 console.log(`${chalk.green('STARTED:')} RSS Feed Fetcher.`);
                 for (const feed of feeds) {
                     const rss = await parser.parseURL(feed.url);
+                    const cutoffDate = new Date();
+                    console.log(`${chalk.green('CURRENT DATE:')} ${cutoffDate}`);
+                    cutoffDate.setMonth(cutoffDate.getMonth() - 6);  // set to 6 months ago
+                    console.log(`${chalk.green('CUTOFF DATE:')} ${cutoffDate}`);
 
                     for (const item of rss.items) {
                         let pin_days = 0;
                         const itemDate = new Date(item['dc:date']);
-                        const cutoffDate = new Date();
-                        console.log(`${chalk.green('CURRENT DATE:')} ${cutoffDate}`);
-                        cutoffDate.setMonth(cutoffDate.getMonth() - 6);  // set to 6 months ago
-                        console.log(`${chalk.green('CUTOFF DATE:')} ${cutoffDate}`);
+                        console.log(`${chalk.green('ITEM DATE:')} ${cutoffDate}`);
+
                         //if item is newer than 6 months old, continue
                         if (itemDate > cutoffDate) { 
+                            console.log(`${chalk.green('RECENT:')} true`);
                             // if has categories then see if it's a pin
                             if (feed.pinCategories && item.categories) {
                                 for (const category of item.categories) {

--- a/main.js
+++ b/main.js
@@ -217,7 +217,7 @@ const bot = new LemmyBot.LemmyBot({
                                         if (community.exclude) {
                                             console.log(`${chalk.green('FETCHING:')} exclude feeds for ${community.slug}`);
                                             for (const excludeFeed of community.exclude) {
-                                                const excludeRss = await parser.parseURL(excludeFeed);
+                                                const excludeRss = await parser.parseURL(excludeFeed.url);
                                                 for (const excludeItem of excludeRss.items) {
                                                     excludeItems.push(excludeItem.link);
                                                 }

--- a/main.js
+++ b/main.js
@@ -173,7 +173,7 @@ const bot = new LemmyBot.LemmyBot({
 
                     for (const item of rss.items) {
                         let pin_days = 0;
-                        const itemDate = new Date(item.dc:date);
+                        const itemDate = new Date(item['dc:date']);
                         const cutoffDate = new Date();
                         cutoffDate.setMonth(cutoffDate.getMonth() - 6);  // set to 6 months ago
 

--- a/main.js
+++ b/main.js
@@ -179,7 +179,7 @@ const bot = new LemmyBot.LemmyBot({
 
                     for (const item of rss.items) {
                         let pin_days = 0;
-                        const itemDate = new Date(item['dc:date']);
+                        const itemDate = new Date(item['dc:date'].trim());
                         console.log(`${chalk.green('ITEM DATE:')} ${itemDate}`);
 
                         //if item is newer than 6 months old, continue

--- a/main.js
+++ b/main.js
@@ -238,6 +238,7 @@ const bot = new LemmyBot.LemmyBot({
                                 }
                                 console.log(`${chalk.green('ADDED:')} ${item.link} for ${pin_days} days`);
                             });
+                        console.log(`${chalk.green('COMPLETE:')} RSS FEED FETCHER.`);
                         }
                     }
                 }

--- a/main.js
+++ b/main.js
@@ -61,8 +61,6 @@ const db = new sqlite3.Database('mega.sqlite3', (err) => {
 
 // -----------------------------------------------------------------------------
 // Data
-// 
-
 
 const communities = [
     {
@@ -114,8 +112,6 @@ const communities = [
 //         content: 'content'
 //     }
 // ]
-//
-
 
 const feeds = [
     {

--- a/main.js
+++ b/main.js
@@ -238,8 +238,9 @@ const bot = new LemmyBot.LemmyBot({
                                 }
                                 console.log(`${chalk.green('ADDED:')} ${item.link} for ${pin_days} days`);
                             });
-                        console.log(`${chalk.green('COMPLETE:')} RSS FEED FETCHER.`);
+                        
                         }
+                    console.log(`${chalk.green('COMPLETE:')} Feed ${feed.name} processed.`);
                     }
                 }
             }

--- a/main.js
+++ b/main.js
@@ -74,7 +74,7 @@ const communities = [
         ]
     },
     {
-        slug: 'localpolitics',
+        slug: 'tucsonpolitics',
         instance: 'tucson.social',
         feeds: [
             'localpolitics',

--- a/main.js
+++ b/main.js
@@ -200,6 +200,7 @@ const bot = new LemmyBot.LemmyBot({
                                 if (err) {
                                     if (err.message.includes('UNIQUE constraint failed')) {
                                         // do nothing
+                                        console.log(`${chalk.green('PRESENT:')} ${item.link} already present`);
                                         return;
                                     } else {
                                         return console.error(err.message);

--- a/main.js
+++ b/main.js
@@ -208,7 +208,7 @@ const bot = new LemmyBot.LemmyBot({
     },
     schedule: [
         {
-            cronExpression: '0 */5 * * * *',
+            cronExpression: '0 */20 * * * *',
             timezone: 'America/Toronto',
             doTask: async ({getCommunityId, createPost}) => {
                 console.log(`${chalk.green('STARTED:')} RSS Feed Fetcher.`);


### PR DESCRIPTION
The joinfeeds array, when present, fetches all feeds in the list and retains those that are common between them. This is processed first.

The exclude array, when present, fetches all feeds in the list and excludes those entries from the feed.

The datefield is compared to the date of today minus 6 months anything older is not processed. It is now a required parameter of `feeds`.

Also perhaps more console logging than you want, but I found useful. Let me know if I should clean that out.